### PR TITLE
Enable UPDATE operations via POST

### DIFF
--- a/src/api/types/ormInterfaces.ts
+++ b/src/api/types/ormInterfaces.ts
@@ -90,7 +90,9 @@ export type RequestQueryBody<
     Overrides extends { [key: string]: any } = {}
 > = Method extends 'GET' | 'PUT' | 'DELETE'
     ? iAPI<RequestGetPutDeleteBody<Modify<T, Overrides> & Custom>>
-    : iAPI<Modify<T, Overrides> & Custom>;
+    : Method extends 'POST'
+        ? iAPI<RequestGetPutDeleteBody<Modify<T, Overrides> & Custom> & Modify<T, Overrides> & Custom>
+        : iAPI<Modify<T, Overrides> & Custom>;
 
 export interface iCacheAPI<ResponseDataType = any> {
     requestArgumentsSerialized: string;


### PR DESCRIPTION
## Summary
- allow the `UPDATE` keyword to be sent in POST requests by extending `RequestQueryBody`

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_687ae1529f4883259219e08620e39046