### PR TITLE
Fix alias resolution in query builder

### DIFF
--- a/src/api/orm/builders/ConditionBuilder.ts
+++ b/src/api/orm/builders/ConditionBuilder.ts
@@ -8,6 +8,8 @@ export abstract class ConditionBuilder<
     G extends OrmGenerics
 > extends AggregateBuilder<G> {
 
+    protected aliasMappings: Record<string, string> = {};
+
     abstract build(table: string): SqlBuilderResult;
 
     execute(): Promise<DetermineResponseDataType<G['RequestMethod'], G['RestTableInterface']>> {
@@ -26,13 +28,13 @@ export abstract class ConditionBuilder<
     ]);
 
     private isTableReference(val: any): boolean {
-        console.log(val)
-        const [tableName] = val.split('.');
-        const is  =  typeof val === 'string' &&
+        if (typeof val !== 'string' || !val.includes('.')) return false;
+        const [prefix, column] = val.split('.');
+        const tableName = this.aliasMappings[prefix] ?? prefix;
+        return (
             typeof this.config.C6?.TABLES[tableName] === 'object' &&
-            val in this.config.C6.TABLES[tableName].COLUMNS;
-        console.log(val, is)
-        return is
+            column in this.config.C6.TABLES[tableName].COLUMNS
+        );
     }
 
     private validateOperator(op: string) {

--- a/src/api/orm/builders/JoinBuilder.ts
+++ b/src/api/orm/builders/JoinBuilder.ts
@@ -11,6 +11,9 @@ export abstract class JoinBuilder<G extends OrmGenerics> extends ConditionBuilde
 
             for (const raw in joinArgs[joinType]) {
                 const [table, alias] = raw.split(' ');
+                if (alias) {
+                    this.aliasMappings[alias] = table;
+                }
                 const onClause = this.buildBooleanJoinedConditions(joinArgs[joinType][raw], true, params);
                 const joinSql = alias ? `\`${table}\` AS \`${alias}\`` : `\`${table}\``;
                 sql += ` ${joinKind} JOIN ${joinSql} ON ${onClause}`;

--- a/src/api/orm/queries/DeleteQueryBuilder.ts
+++ b/src/api/orm/queries/DeleteQueryBuilder.ts
@@ -6,6 +6,7 @@ export class DeleteQueryBuilder<G extends OrmGenerics> extends JoinBuilder<G> {
     build(
         table: string
     ): SqlBuilderResult {
+        this.aliasMappings = {};
         const params = this.useNamedParams ? {} : [];
 
         let sql = `DELETE \`${table}\` FROM \`${table}\``;

--- a/src/api/orm/queries/PostQueryBuilder.ts
+++ b/src/api/orm/queries/PostQueryBuilder.ts
@@ -14,6 +14,7 @@ export class PostQueryBuilder<G extends OrmGenerics> extends ConditionBuilder<G>
     }
 
     build(table: string) {
+        this.aliasMappings = {};
         const verb = C6C.REPLACE in this.request ? C6C.REPLACE : C6C.INSERT;
         const body = verb in this.request ? this.request[verb] : this.request;
         const keys = Object.keys(body);

--- a/src/api/orm/queries/SelectQueryBuilder.ts
+++ b/src/api/orm/queries/SelectQueryBuilder.ts
@@ -8,6 +8,7 @@ export class SelectQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
         table: string,
         isSubSelect: boolean = false
     ): SqlBuilderResult {
+        this.aliasMappings = {};
         const args = this.request;
         const params = this.useNamedParams ? {} : [];
         const selectList = args.SELECT ?? ['*'];

--- a/src/api/orm/queries/UpdateQueryBuilder.ts
+++ b/src/api/orm/queries/UpdateQueryBuilder.ts
@@ -8,6 +8,7 @@ export class UpdateQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
     build(
         table: string,
     ): SqlBuilderResult {
+        this.aliasMappings = {};
         const args = this.request;
         const params = this.useNamedParams ? {} : [];
         let sql = `UPDATE \`${table}\``;


### PR DESCRIPTION
## Summary
- reset alias mappings when building queries
- capture join aliases for table reference checks
- handle aliased fields when validating references

## Testing
- `npm test` *(fails: Cannot find name 'require' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687eee85ce0c8325a52587c24d44e7c9