### PR TITLE
Fix verbose SQL request logging

### DIFF
--- a/src/api/executors/SqlExecutor.ts
+++ b/src/api/executors/SqlExecutor.ts
@@ -20,8 +20,7 @@ export class SqlExecutor<
         const method = this.config.requestMethod;
 
         this.config.verbose && console.log(`[SQL EXECUTOR] ▶️ Executing ${method} on table "${TABLE_NAME}"`);
-        this.config.verbose && console.log(`[SQL EXECUTOR] 🧩 Request body:`, this.request.body);
-        this.config.verbose && console.log(`[SQL EXECUTOR] 🧩 Request query:`, this.request.query);
+        this.config.verbose && console.log(`[SQL EXECUTOR] 🧩 Request:`, this.request);
 
 
         switch (method) {


### PR DESCRIPTION
## Summary
- log the entire request object instead of `body`/`query` which were undefined

## Testing
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_687ef546ac048325b08de31e24c4972c