### PR TITLE
Add column reference validation

### DIFF
--- a/src/api/orm/builders/JoinBuilder.ts
+++ b/src/api/orm/builders/JoinBuilder.ts
@@ -12,6 +12,7 @@ export abstract class JoinBuilder<G extends OrmGenerics> extends ConditionBuilde
 
             for (const raw in joinArgs[joinType]) {
                 const [table, alias] = raw.split(' ');
+                this.aliasMap[alias || table] = table;
                 const onClause = this.buildBooleanJoinedConditions(joinArgs[joinType][raw], true, params);
                 const joinSql = alias ? `\`${table}\` AS \`${alias}\`` : `\`${table}\``;
                 sql += ` ${joinKind} JOIN ${joinSql} ON ${onClause}`;

--- a/src/api/orm/queries/DeleteQueryBuilder.ts
+++ b/src/api/orm/queries/DeleteQueryBuilder.ts
@@ -7,6 +7,7 @@ export class DeleteQueryBuilder<G extends OrmGenerics> extends JoinBuilder<G> {
         table: string
     ): SqlBuilderResult {
         const params = this.useNamedParams ? {} : [];
+        this.initAlias(table, this.request.JOIN);
 
         let sql = `DELETE \`${table}\` FROM \`${table}\``;
 

--- a/src/api/orm/queries/SelectQueryBuilder.ts
+++ b/src/api/orm/queries/SelectQueryBuilder.ts
@@ -9,6 +9,7 @@ export class SelectQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
         isSubSelect: boolean = false
     ): SqlBuilderResult {
         const args = this.request;
+        this.initAlias(table, args.JOIN);
         const params = this.useNamedParams ? {} : [];
         const selectList = args.SELECT ?? ['*'];
         const selectFields = selectList

--- a/src/api/orm/queries/UpdateQueryBuilder.ts
+++ b/src/api/orm/queries/UpdateQueryBuilder.ts
@@ -10,6 +10,7 @@ export class UpdateQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
     ): SqlBuilderResult {
         const args = this.request;
         const params = this.useNamedParams ? {} : [];
+        this.initAlias(table, args.JOIN);
         let sql = `UPDATE \`${table}\``;
 
         if (args.JOIN) {


### PR DESCRIPTION
## Summary
- track table aliases in `ConditionBuilder`
- detect when SQL columns are unknown or injection attempts
- register aliases while building JOINs
- initialize alias map in query builders

## Testing
- `npx -y barrelsby -d ./src --delete --exclude '(jestHoc|\.test|\.d).(js|tsx?)$' --exportDefault --verbose`
- `npx -y tsc` *(fails: cannot find declarations)*
- `node test/test.js` *(fails: require not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_687e977d294c832593101cc5285c8695