### PR TITLE
Fix fully qualified columns in requests

### DIFF
--- a/src/api/convertForRequestBody.ts
+++ b/src/api/convertForRequestBody.ts
@@ -27,7 +27,7 @@ export default function <
     for (const tableDefinition of tableDefinitions) {
         for (const value of Object.keys(restfulObject)) {
             const shortReference = value.toUpperCase();
-
+            
             if ([
                 C6Constants.GET,
                 C6Constants.POST,
@@ -66,6 +66,28 @@ export default function <
                         const regex: RegExp = regexValidations[errorMessage];
                         if (!regex.test(columnValue)) {
                             const devErrorMessage = `Failed to match regex (${regex}) for column (${longName})`;
+                            regexErrorHandler(errorMessage || devErrorMessage);
+                            throw new Error(devErrorMessage);
+                        }
+                    }
+                }
+            } else if (Object.values(tableDefinition.COLUMNS).includes(value)) {
+                // Already a fully qualified column name
+                const columnValue = restfulObject[value];
+                payload[value] = columnValue;
+
+                const regexValidations = tableDefinition.REGEX_VALIDATION[value];
+
+                if (regexValidations instanceof RegExp) {
+                    if (!regexValidations.test(columnValue)) {
+                        regexErrorHandler(`Failed to match regex (${regexValidations}) for column (${value})`);
+                        throw new Error(`Failed to match regex (${regexValidations}) for column (${value})`);
+                    }
+                } else if (typeof regexValidations === 'object' && regexValidations !== null) {
+                    for (const errorMessage in regexValidations) {
+                        const regex: RegExp = regexValidations[errorMessage];
+                        if (!regex.test(columnValue)) {
+                            const devErrorMessage = `Failed to match regex (${regex}) for column (${value})`;
                             regexErrorHandler(errorMessage || devErrorMessage);
                             throw new Error(devErrorMessage);
                         }


### PR DESCRIPTION
## Summary
- support sending fully qualified column names when building request bodies

## Testing
- `npm test` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68801348fee88325a6c9ce28476bff23