### PR TITLE
Add DISTINCT support within Select fields

### DIFF
--- a/src/api/orm/builders/AggregateBuilder.ts
+++ b/src/api/orm/builders/AggregateBuilder.ts
@@ -20,11 +20,17 @@ export abstract class AggregateBuilder<G extends OrmGenerics> extends Executor<G
         }
 
         const F = String(fn).toUpperCase();
-        const argList = args.map(arg =>
-            Array.isArray(arg) ? this.buildAggregateField(arg) : arg
-        ).join(', ');
+        const argList = args
+            .map(arg => Array.isArray(arg) ? this.buildAggregateField(arg) : arg)
+            .join(', ');
 
-        let expr = `${F}(${argList})`;
+        let expr: string;
+
+        if (F === 'DISTINCT') {
+            expr = `DISTINCT ${argList}`;
+        } else {
+            expr = `${F}(${argList})`;
+        }
 
         if (alias) {
             expr += ` AS ${alias}`;

--- a/src/api/orm/builders/ConditionBuilder.ts
+++ b/src/api/orm/builders/ConditionBuilder.ts
@@ -58,7 +58,7 @@ export abstract class ConditionBuilder<
     private isTableReference(val: any): boolean {
         if (typeof val !== 'string' || !val.includes('.')) return false;
         const [prefix, column] = val.split('.');
-        const tableName = this.aliasMappings[prefix] ?? prefix;
+        const tableName = this.aliasMap[prefix] ?? prefix;
         return (
             typeof this.config.C6?.TABLES[tableName] === 'object' &&
             val in this.config.C6.TABLES[tableName].COLUMNS &&
@@ -112,6 +112,7 @@ export abstract class ConditionBuilder<
             }
 
             const leftIsCol = this.isColumnRef(column);
+            const leftIsRef = this.isTableReference(column);
             const rightIsCol = typeof value === 'string' && this.isColumnRef(value);
 
             if (!leftIsCol && !rightIsCol) {

--- a/src/api/orm/queries/DeleteQueryBuilder.ts
+++ b/src/api/orm/queries/DeleteQueryBuilder.ts
@@ -6,7 +6,7 @@ export class DeleteQueryBuilder<G extends OrmGenerics> extends JoinBuilder<G> {
     build(
         table: string
     ): SqlBuilderResult {
-        this.aliasMappings = {};
+        this.aliasMap = {};
         const params = this.useNamedParams ? {} : [];
         this.initAlias(table, this.request.JOIN);
 

--- a/src/api/orm/queries/PostQueryBuilder.ts
+++ b/src/api/orm/queries/PostQueryBuilder.ts
@@ -14,7 +14,7 @@ export class PostQueryBuilder<G extends OrmGenerics> extends ConditionBuilder<G>
     }
 
     build(table: string) {
-        this.aliasMappings = {};
+        this.aliasMap = {};
         const verb = C6C.REPLACE in this.request ? C6C.REPLACE : C6C.INSERT;
         const body = verb in this.request ? this.request[verb] : this.request;
         const keys = Object.keys(body);

--- a/src/api/orm/queries/SelectQueryBuilder.ts
+++ b/src/api/orm/queries/SelectQueryBuilder.ts
@@ -8,7 +8,7 @@ export class SelectQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
         table: string,
         isSubSelect: boolean = false
     ): SqlBuilderResult {
-        this.aliasMappings = {};
+        this.aliasMap = {};
         const args = this.request;
         this.initAlias(table, args.JOIN);
         const params = this.useNamedParams ? {} : [];

--- a/src/api/orm/queries/UpdateQueryBuilder.ts
+++ b/src/api/orm/queries/UpdateQueryBuilder.ts
@@ -8,7 +8,7 @@ export class UpdateQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
     build(
         table: string,
     ): SqlBuilderResult {
-        this.aliasMappings = {};
+        this.aliasMap = {};
         const args = this.request;
         const params = this.useNamedParams ? {} : [];
         this.initAlias(table, args.JOIN);


### PR DESCRIPTION
## Summary
- handle `DISTINCT` inside aggregate field builder
- drop DISTINCT from request body schema and sanitization
- generate SELECT statements without a top-level DISTINCT flag

## Testing
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6885656a9b5483258a65d0c6c689c709