### PR TITLE
Avoid moving PK into URL for POST requests

### DIFF
--- a/src/api/executors/HttpExecutor.ts
+++ b/src/api/executors/HttpExecutor.ts
@@ -402,7 +402,8 @@ export class HttpExecutor<
             // A part of me exists that wants to remove this, but it's a good feature
             // this allows developers the ability to cache requests based on primary key
             // for tables like `photos` this can be a huge performance boost
-            if (undefined !== query
+            if (POST !== requestMethod
+                && undefined !== query
                 && null !== query
                 && undefined !== primaryKey
                 && primaryKey in query) {


### PR DESCRIPTION
## Summary
- prevent HttpExecutor from removing primary key from request body when handling POST requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890cfa54a1483259d1a8fa728a11242