### PR TITLE
feat: add ST_CONTAINS spatial predicate

### DIFF
--- a/src/api/orm/builders/ConditionBuilder.ts
+++ b/src/api/orm/builders/ConditionBuilder.ts
@@ -52,7 +52,16 @@ export abstract class ConditionBuilder<
         C6C.IS, C6C.IS_NOT,
         C6C.BETWEEN, 'NOT BETWEEN',
         C6C.MATCH_AGAINST,
-        C6C.ST_DISTANCE_SPHERE
+        C6C.ST_DISTANCE_SPHERE,
+        // spatial predicates
+        C6C.ST_CONTAINS,
+        C6C.ST_INTERSECTS,
+        C6C.ST_WITHIN,
+        C6C.ST_CROSSES,
+        C6C.ST_DISJOINT,
+        C6C.ST_EQUALS,
+        C6C.ST_OVERLAPS,
+        C6C.ST_TOUCHES
     ]);
 
     private isTableReference(val: any): boolean {
@@ -112,6 +121,19 @@ export abstract class ConditionBuilder<
                     const [col1, col2] = op;
                     const threshold = Array.isArray(value) ? value[0] : value;
                     return `ST_Distance_Sphere(${col1}, ${col2}) < ${this.addParam(params, '', threshold)}`;
+                }
+                if ([
+                    C6C.ST_CONTAINS,
+                    C6C.ST_INTERSECTS,
+                    C6C.ST_WITHIN,
+                    C6C.ST_CROSSES,
+                    C6C.ST_DISJOINT,
+                    C6C.ST_EQUALS,
+                    C6C.ST_OVERLAPS,
+                    C6C.ST_TOUCHES
+                ].includes(column)) {
+                    const [geom1, geom2] = op;
+                    return `${column}(${geom1}, ${geom2})`;
                 }
             }
 

--- a/src/api/orm/queryHelpers.ts
+++ b/src/api/orm/queryHelpers.ts
@@ -16,3 +16,7 @@ export const fieldEq = (leftCol: string, rightCol: string, leftAlias: string, ri
 // ST_Distance_Sphere for aliased fields
 export const distSphere = (fromCol: string, toCol: string, fromAlias: string, toAlias: string): any[] =>
     [C6C.ST_DISTANCE_SPHERE, F(fromCol, fromAlias), F(toCol, toAlias)];
+
+// ST_Contains for map envelope/shape queries
+export const stContains = (envelope: string, shape: string): any[] =>
+    [C6C.ST_CONTAINS, envelope, shape];


### PR DESCRIPTION
## Summary
- allow spatial predicates like ST_Contains in condition builder
- add `stContains` helper for map envelope queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689839cc5f988325820956f755de41d9