### PR TITLE
Add ST_MAKEENVELOPE constant and bbox helper

### DIFF
--- a/src/api/C6Constants.ts
+++ b/src/api/C6Constants.ts
@@ -120,6 +120,7 @@ export const C6Constants = {
     ST_GEOMFROMWKB: 'ST_GeomFromWKB',
     ST_INTERSECTS: 'ST_Intersects',
     ST_LENGTH: 'ST_Length',
+    ST_MAKEENVELOPE: 'ST_MakeEnvelope',
     ST_OVERLAPS: 'ST_Overlaps',
     ST_POINT: 'ST_Point',
     ST_SETSRID: 'ST_SetSRID',

--- a/src/api/orm/queryHelpers.ts
+++ b/src/api/orm/queryHelpers.ts
@@ -16,3 +16,9 @@ export const fieldEq = (leftCol: string, rightCol: string, leftAlias: string, ri
 // ST_Distance_Sphere for aliased fields
 export const distSphere = (fromCol: string, toCol: string, fromAlias: string, toAlias: string): any[] =>
     [C6C.ST_DISTANCE_SPHERE, F(fromCol, fromAlias), F(toCol, toAlias)];
+
+// Build a bounding-box expression
+export const bbox = (minLng: number, minLat: number, maxLng: number, maxLat: number): any[] =>
+    [C6C.ST_SRID, [C6C.ST_MAKEENVELOPE,
+        [C6C.ST_POINT, minLng, minLat],
+        [C6C.ST_POINT, maxLng, maxLat]], 4326];

--- a/test/queryHelpers.test.js
+++ b/test/queryHelpers.test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { bbox, C6C } from '../dist/index.esm.js';
+
+// Verify basic bounding box construction
+const expected = [
+  C6C.ST_SRID,
+  [
+    C6C.ST_MAKEENVELOPE,
+    [C6C.ST_POINT, 10, 20],
+    [C6C.ST_POINT, 30, 40],
+  ],
+  4326,
+];
+const actual = bbox(10, 20, 30, 40);
+assert.deepStrictEqual(actual, expected);
+console.log('\u001B[32m✓\u001B[39m bbox basic structure test passed');
+
+// Negative coordinate handling
+const expectedNegative = [
+  C6C.ST_SRID,
+  [
+    C6C.ST_MAKEENVELOPE,
+    [C6C.ST_POINT, -10, -20],
+    [C6C.ST_POINT, -30, -40],
+  ],
+  4326,
+];
+const actualNegative = bbox(-10, -20, -30, -40);
+assert.deepStrictEqual(actualNegative, expectedNegative);
+console.log('\u001B[32m✓\u001B[39m bbox negative coordinates test passed');
+
+// Swapped min/max arguments
+const expectedSwapped = [
+  C6C.ST_SRID,
+  [
+    C6C.ST_MAKEENVELOPE,
+    [C6C.ST_POINT, 30, 40],
+    [C6C.ST_POINT, 10, 20],
+  ],
+  4326,
+];
+const actualSwapped = bbox(30, 40, 10, 20);
+assert.deepStrictEqual(actualSwapped, expectedSwapped);
+console.log('\u001B[32m✓\u001B[39m bbox swapped arguments test passed');

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+import './queryHelpers.test.js';
 import assert from 'assert';
 
 // basic sanity test to ensure test infrastructure runs


### PR DESCRIPTION
## Summary
- support MySQL ST_MakeEnvelope via new `ST_MAKEENVELOPE` constant
- add `bbox` query helper for constructing bounding box expressions
- cover `bbox` helper with tests for standard and edge-case coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689839d2c7c88325898d218f1d5c3a3e