### PR TITLE
fix: add dynamic import to C6 template

### DIFF
--- a/scripts/assets/handlebars/C6.ts.handlebars
+++ b/scripts/assets/handlebars/C6.ts.handlebars
@@ -1,12 +1,15 @@
 // noinspection JSUnusedGlobalSymbols,SpellCheckingInspection
 
-import type {
+import {
+    C6Constants,
     C6RestfulModel,
     iC6Object,
+    iDynamicApiImport,
     iRest,
     OrmGenerics,
+    removePrefixIfExists,
+    restOrm,
 } from "@carbonorm/carbonnode";
-import { C6Constants, restOrm } from "@carbonorm/carbonnode";
 import type * as GeoJSON from "geojson";{{#if CUSTOM_IMPORTS}},
 {{{CUSTOM_IMPORTS}}}{{/if}}
 
@@ -110,6 +113,29 @@ export type RestTableInterfaces = {{{RestTableInterfaces}}};
 export const C6 : iC6Object<RestTableInterfaces> = {
     ...C6Constants,
     C6VERSION: '{{C6VERSION}}',
+    IMPORT: async (tableName: string) : Promise<iDynamicApiImport> => {
+
+        tableName = tableName.toLowerCase();
+
+        // if tableName is not a key in the TABLES object then throw an error
+        if (!TABLES[tableName as RestShortTableNames]) {
+            const error = (table: string) => {
+                throw Error('Table (' + table + ') does not exist in the TABLES object. Possible values include (' + Object.keys(TABLES).join(', ') + ')');
+            }
+            if (!tableName.startsWith(RestTablePrefix.toLowerCase())) {
+                error(tableName);
+            }
+            tableName = removePrefixIfExists(tableName, RestTablePrefix);
+            if (!TABLES[tableName as RestShortTableNames]) {
+                error(tableName);
+            }
+        }
+        // This will rightfully throw a dynamic import warning in the console, but it is necessary to use dynamic imports
+        return import(/* @vite-ignore */ './' + (tableName.split('_')
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                .join('_')) + '.ts');
+
+    },
     PREFIX: RestTablePrefix,
     TABLES: TABLES,
     ORM: {},


### PR DESCRIPTION
## Summary
- inline dynamic import logic in generated C6 bindings
- remove dynamic import cache and helper function

## Testing
- `npm run c6`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b91bb3cb2883259dc097f5fda07324