### PR TITLE
fix: allow GET requests without primary key

### DIFF
--- a/src/__tests__/normalizeSingularRequest.test.ts
+++ b/src/__tests__/normalizeSingularRequest.test.ts
@@ -92,4 +92,18 @@ describe('normalizeSingularRequest', () => {
     const out = normalizeSingularRequest('GET', complex, model);
     expect(out).toBe(complex);
   });
+
+  it('allows GET requests with only pagination', () => {
+    const model = makeModel('actor', ['actor_id']);
+    const req = { [C6C.PAGINATION]: { LIMIT: 100, PAGE: 1 } } as any;
+    const out = normalizeSingularRequest('GET', req, model);
+    expect(out).toBe(req);
+  });
+
+  it('allows empty GET requests', () => {
+    const model = makeModel('actor', ['actor_id']);
+    const req = {} as any;
+    const out = normalizeSingularRequest('GET', req, model);
+    expect(out).toBe(req);
+  });
 });

--- a/src/api/utils/normalizeSingularRequest.ts
+++ b/src/api/utils/normalizeSingularRequest.ts
@@ -33,6 +33,13 @@ export function normalizeSingularRequest<
   const hasComplexKeys = keys.some(k => k !== C6C.PAGINATION && specialKeys.has(k));
   if (hasComplexKeys) return request; // already complex
 
+  // For GET requests, if there are no non-special keys (e.g., only PAGINATION),
+  // treat it as a multi-row request and leave it unchanged.
+  if (requestMethod === C6C.GET) {
+    const hasNonSpecialKeys = keys.some(k => !specialKeys.has(k));
+    if (!hasNonSpecialKeys) return request;
+  }
+
   // We treat it as singular when it's not complex.
   // For GET, PUT, DELETE only
   if (!(requestMethod === C6C.GET || requestMethod === C6C.PUT || requestMethod === C6C.DELETE)) {


### PR DESCRIPTION
## Summary
- do not force primary keys for GET requests that only include pagination or are empty
- cover GET pagination and empty scenarios in normalizeSingularRequest tests

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run format` *(fails: Missing script: "format")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d878ee9883259cd86cbea2cdbfd0