### PR TITLE
fix: trim table prefixes in update builder

### DIFF
--- a/src/__tests__/sqlBuilders.test.ts
+++ b/src/__tests__/sqlBuilders.test.ts
@@ -82,6 +82,24 @@ describe('SQL Builders', () => {
     expect(params).toEqual(['ALICE', 5]);
   });
 
+  it('builds UPDATE when columns are fully qualified', () => {
+    const config = buildTestConfig();
+    const qb = new UpdateQueryBuilder(config as any, {
+      [C6C.UPDATE]: {
+        'actor.first_name': 'ALICIA',
+      },
+      WHERE: {
+        'actor.actor_id': [C6C.EQUAL, 7],
+      },
+    } as any, false);
+
+    const { sql, params } = qb.build('actor');
+
+    expect(sql).toContain('`first_name` = ?');
+    expect(sql).toContain('WHERE (actor.actor_id) = ?');
+    expect(params).toEqual(['ALICIA', 7]);
+  });
+
   it('builds DELETE with JOIN and WHERE', () => {
     const config = buildTestConfig();
     const qb = new DeleteQueryBuilder(config as any, {

--- a/src/api/orm/queries/UpdateQueryBuilder.ts
+++ b/src/api/orm/queries/UpdateQueryBuilder.ts
@@ -4,6 +4,14 @@ import { PaginationBuilder } from '../builders/PaginationBuilder';
 import {SqlBuilderResult} from "../utils/sqlUtils";
 
 export class UpdateQueryBuilder<G extends OrmGenerics> extends PaginationBuilder<G>{
+    private trimTablePrefix(table: string, column: string): string {
+        if (!column.includes('.')) return column;
+        const [prefix, col] = column.split('.', 2);
+        if (prefix !== table) {
+            throw new Error(`Invalid prefixed column: '${column}'. Expected prefix '${table}.'`);
+        }
+        return col;
+    }
 
     build(
         table: string,
@@ -23,7 +31,7 @@ export class UpdateQueryBuilder<G extends OrmGenerics> extends PaginationBuilder
         }
 
         const setClauses = Object.entries(this.request[C6C.UPDATE])
-            .map(([col, val]) => `\`${col}\` = ${this.addParam(params, col, val)}`);
+            .map(([col, val]) => `\`${this.trimTablePrefix(table, col)}\` = ${this.addParam(params, col, val)}`);
 
         sql += ` SET ${setClauses.join(', ')}`;
 


### PR DESCRIPTION
## Summary
- ensure UpdateQueryBuilder strips table prefixes from SET clause columns
- add tests covering updates with fully qualified column names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba4eeda71c8325a50e2c7432a0765f