### PR TITLE
test: add express server for HTTP e2e

### DIFF
--- a/src/__tests__/expressServer.e2e.test.ts
+++ b/src/__tests__/expressServer.e2e.test.ts
@@ -1,0 +1,41 @@
+import mysql from "mysql2/promise";
+import {describe, it, expect, beforeAll, afterAll} from "vitest";
+import {C6, Actor, GLOBAL_REST_PARAMETERS} from "./sakila-db/C6.js";
+import {createTestServer} from "../api/handlers/createTestServer";
+import {C6C} from "../api/C6Constants";
+import axiosInstance from "../api/axiosInstance";
+
+let server: any;
+let pool: mysql.Pool;
+
+beforeAll(async () => {
+    pool = mysql.createPool({
+        host: "127.0.0.1",
+        user: "root",
+        password: "password",
+        database: "sakila",
+    });
+
+    const app = createTestServer({C6, mysqlPool: pool});
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const {port} = server.address();
+    GLOBAL_REST_PARAMETERS.restURL = `http://127.0.0.1:${port}/rest/`;
+    GLOBAL_REST_PARAMETERS.axios = axiosInstance;
+});
+
+afterAll(async () => {
+    await pool.end();
+    await new Promise<void>((resolve) => server.close(resolve));
+});
+
+describe("ExpressHandler e2e", () => {
+    it("handles GET requests", async () => {
+        const result = await Actor.Get({
+            [C6C.PAGINATION]: { [C6C.LIMIT]: 1 },
+        } as any);
+        const data = (result as any)?.data ?? result;
+        expect(Array.isArray(data.rest)).toBe(true);
+        expect(data.rest.length).toBeGreaterThan(0);
+    });
+});

--- a/src/api/handlers/createTestServer.ts
+++ b/src/api/handlers/createTestServer.ts
@@ -1,0 +1,14 @@
+import express, {Express} from "express";
+import {Pool} from "mysql2/promise";
+import {iC6Object} from "api/types/ormInterfaces";
+import {ExpressHandler} from "./ExpressHandler";
+
+export function createTestServer({C6, mysqlPool}: {C6: iC6Object; mysqlPool: Pool;}): Express {
+    const app = express();
+    app.use(express.json());
+    app.all("/rest/:table", ExpressHandler({C6, mysqlPool}));
+    app.all("/rest/:table/:primary", ExpressHandler({C6, mysqlPool}));
+    return app;
+}
+
+export default createTestServer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export * from "./api/executors/Executor";
 export * from "./api/executors/HttpExecutor";
 export * from "./api/executors/SqlExecutor";
 export * from "./api/handlers/ExpressHandler";
+export { default as createTestServer } from "./api/handlers/createTestServer";
+export * from "./api/handlers/createTestServer";
 export * from "./api/orm/queryHelpers";
 export * from "./api/orm/builders/AggregateBuilder";
 export * from "./api/orm/builders/ConditionBuilder";


### PR DESCRIPTION
## Summary
- add `createTestServer` helper to spin up Express + C6 ORM
- cover ExpressHandler with an end-to-end HTTP test
- export test server helper from package index

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run format` *(fails: Missing script "format")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc92271f08325b813101184dec193