### PR TITLE
fix: handle fully qualified singular keys

### DIFF
--- a/scripts/assets/handlebars/C6.test.ts.handlebars
+++ b/scripts/assets/handlebars/C6.test.ts.handlebars
@@ -59,5 +59,32 @@ describe('sakila-db generated C6 bindings', () => {
             await waitForRequests();
         });
     }
+
+    it('[actor] PUT fully qualified keys', async () => {
+        const Actor = C6.ORM.Actor;
+        const testId = 1;
+
+        let result = await Actor.Get({ [Actor.ACTOR_ID]: testId } as any);
+        let data = result?.data ?? result;
+        const originalLastName = data?.rest?.[0]?.last_name;
+
+        await Actor.Put({
+            [Actor.ACTOR_ID]: testId,
+            [Actor.LAST_NAME]: 'Updated',
+        } as any);
+
+        result = await Actor.Get({
+            [Actor.ACTOR_ID]: testId,
+            cacheResults: false,
+        } as any);
+        data = result?.data ?? result;
+        expect(data?.rest?.[0]?.last_name).toBe('Updated');
+
+        await Actor.Put({
+            [Actor.ACTOR_ID]: testId,
+            [Actor.LAST_NAME]: originalLastName,
+        } as any);
+        await waitForRequests();
+    });
 });
 

--- a/src/__tests__/httpExecutorSingular.e2e.test.ts
+++ b/src/__tests__/httpExecutorSingular.e2e.test.ts
@@ -63,6 +63,15 @@ describe("HttpExecutor singular e2e", () => {
     expect(data.rest).toHaveLength(1);
     expect(data.rest[0].first_name).toBe("Updated");
 
+    // PUT using fully qualified keys
+    await Actor.Put({
+      [Actor.ACTOR_ID]: testId,
+      [Actor.FIRST_NAME]: "UpdatedFQ",
+    } as any);
+    data = await Actor.Get({ actor_id: testId, cacheResults: false } as any);
+    expect(data.rest).toHaveLength(1);
+    expect(data.rest[0].first_name).toBe("UpdatedFQ");
+
     // DELETE singular
     await Actor.Delete({ actor_id: testId } as any);
     data = await Actor.Get({ actor_id: testId, cacheResults: false } as any);

--- a/src/__tests__/sakila-db/C6.test.ts
+++ b/src/__tests__/sakila-db/C6.test.ts
@@ -59,5 +59,32 @@ describe('sakila-db generated C6 bindings', () => {
             await waitForRequests();
         });
     }
+
+    it('[actor] PUT fully qualified keys', async () => {
+        const Actor = C6.ORM.Actor;
+        const testId = 1;
+
+        let result = await Actor.Get({ [Actor.ACTOR_ID]: testId } as any);
+        let data = result?.data ?? result;
+        const originalLastName = data?.rest?.[0]?.last_name;
+
+        await Actor.Put({
+            [Actor.ACTOR_ID]: testId,
+            [Actor.LAST_NAME]: 'Updated',
+        } as any);
+
+        result = await Actor.Get({
+            [Actor.ACTOR_ID]: testId,
+            cacheResults: false,
+        } as any);
+        data = result?.data ?? result;
+        expect(data?.rest?.[0]?.last_name).toBe('Updated');
+
+        await Actor.Put({
+            [Actor.ACTOR_ID]: testId,
+            [Actor.LAST_NAME]: originalLastName,
+        } as any);
+        await waitForRequests();
+    });
 });
 

--- a/src/api/convertForRequestBody.ts
+++ b/src/api/convertForRequestBody.ts
@@ -71,8 +71,8 @@ export default function <
                         }
                     }
                 }
-            } else if (Object.values(tableDefinition.COLUMNS).includes(value)) {
-                // Already a fully qualified column name
+            } else if (Object.keys(tableDefinition.COLUMNS).includes(value)) {
+                // Already using a fully qualified column name
                 const columnValue = restfulObject[value];
                 payload[value] = columnValue;
 

--- a/src/api/executors/HttpExecutor.ts
+++ b/src/api/executors/HttpExecutor.ts
@@ -346,7 +346,9 @@ export class HttpExecutor<
 
             // todo - aggregate primary key check with condition check
             // check if PK exists in query, clone so pop does not affect the real data
-            const primaryKey = structuredClone(TABLES[operatingTable]?.PRIMARY)?.pop()?.split('.')?.pop();
+            const primaryKeyList = structuredClone(TABLES[operatingTable]?.PRIMARY);
+            const primaryKeyFullyQualified = primaryKeyList?.pop();
+            const primaryKey = primaryKeyFullyQualified?.split('.')?.pop();
 
             if (needsConditionOrPrimaryCheck) {
 
@@ -370,7 +372,7 @@ export class HttpExecutor<
 
                     if (undefined === query
                         || null === query
-                        || false === primaryKey in query) {
+                        || (!(primaryKey! in query) && !(primaryKeyFullyQualified && primaryKeyFullyQualified in query))) {
 
                         if (true === debug && isLocal()) {
 
@@ -382,8 +384,8 @@ export class HttpExecutor<
 
                     }
 
-                    if (undefined === query?.[primaryKey]
-                        || null === query?.[primaryKey]) {
+                    const providedPrimary = query?.[primaryKey!] ?? (primaryKeyFullyQualified ? query?.[primaryKeyFullyQualified] : undefined);
+                    if (undefined === providedPrimary || null === providedPrimary) {
 
                         toast.error('The primary key (' + primaryKey + ') provided is undefined or null explicitly!!')
 
@@ -401,12 +403,21 @@ export class HttpExecutor<
             if (POST !== requestMethod
                 && undefined !== query
                 && null !== query
-                && undefined !== primaryKey
-                && primaryKey in query) {
+                && undefined !== primaryKey) {
 
-                restRequestUri += query[primaryKey] + '/'
+                const primaryVal = query[primaryKey!] ?? (primaryKeyFullyQualified ? query[primaryKeyFullyQualified] : undefined);
 
-                console.log('query', query, 'primaryKey', primaryKey)
+                if (undefined !== primaryVal) {
+
+                    restRequestUri += primaryVal + '/'
+
+                    console.log('query', query, 'primaryKey', primaryKey)
+
+                } else {
+
+                    console.log('query', query)
+
+                }
 
             } else {
 


### PR DESCRIPTION
## Summary
- allow request builder to recognize fully qualified column names
- extract primary key from fully qualified fields when building HTTP requests
- cover HTTP executor PUT flows using fully qualified column names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca899ffac8325808ea6c5aa39d1e9