### PR TITLE
fix: normalize keys for single-object updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonorm/carbonnode",
-  "version": "3.7.12",
+  "version": "3.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonorm/carbonnode",
-      "version": "3.7.12",
+      "version": "3.7.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonorm/carbonnode",
-  "version": "3.7.20",
+  "version": "3.7.21",
   "browser": "dist/index.umd.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- normalize fully-qualified keys before updating React state
- verify state updates from fully-qualified singular requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf93e13d08325953e56baaa64488d