### PR TITLE
Normalize insert value handling in PostQueryBuilder

### DIFF
--- a/src/__tests__/fixtures/c6.fixture.ts
+++ b/src/__tests__/fixtures/c6.fixture.ts
@@ -43,6 +43,7 @@ export function buildTestConfig() {
     'actor.first_name': 'first_name',
     'actor.last_name': 'last_name',
     'actor.binarycol': 'binarycol',
+    'actor.json_data': 'json_data',
   } as const;
 
   const filmActorCols = {
@@ -62,6 +63,7 @@ export function buildTestConfig() {
 
   // Special-case: mark binary column as BINARY to test conversion
   C6.TABLES.actor.TYPE_VALIDATION['binarycol'].MYSQL_TYPE = 'BINARY(16)';
+  C6.TABLES.actor.TYPE_VALIDATION['json_data'].MYSQL_TYPE = 'JSON';
 
   const baseConfig: iRest<any, any, any> = {
     C6,

--- a/src/__tests__/sqlBuilders.test.ts
+++ b/src/__tests__/sqlBuilders.test.ts
@@ -61,6 +61,34 @@ describe('SQL Builders', () => {
     expect(params).toEqual(['BOB', 'SMITH']);
   });
 
+  it('stringifies plain object inserts for JSON columns', () => {
+    const config = buildTestConfig();
+    const payload = { hello: 'world', nested: { ok: true } };
+    const qb = new PostQueryBuilder(config as any, {
+      [C6C.INSERT]: {
+        'actor.json_data': payload,
+      },
+    } as any, false);
+
+    const { sql, params } = qb.build('actor');
+
+    expect(sql).toContain('`json_data`');
+    expect(params).toEqual([JSON.stringify(payload)]);
+  });
+
+  it('throws on operator-shaped insert payloads', () => {
+    const config = buildTestConfig();
+    const qb = new PostQueryBuilder(config as any, {
+      [C6C.INSERT]: {
+        'actor.first_name': {
+          [C6C.GREATER_THAN]: 'ALICE',
+        },
+      },
+    } as any, false);
+
+    expect(() => qb.build('actor')).toThrowError(/requires two operands/);
+  });
+
   it('builds UPDATE with WHERE and pagination', () => {
     const config = buildTestConfig();
     const qb = new UpdateQueryBuilder(config as any, {

--- a/src/api/orm/queries/PostQueryBuilder.ts
+++ b/src/api/orm/queries/PostQueryBuilder.ts
@@ -18,13 +18,15 @@ export class PostQueryBuilder<G extends OrmGenerics> extends ConditionBuilder<G>
         const verb = C6C.REPLACE in this.request ? C6C.REPLACE : C6C.INSERT;
         const body = verb in this.request ? this.request[verb] : this.request;
         const keys = Object.keys(body);
-        const params: any[] = []
+        const params: any[] | Record<string, any> = this.useNamedParams ? {} : [];
         const placeholders: string[] = []
 
 
         for (const key of keys) {
             const value = body[key];
-            const placeholder = this.addParam(params, key, value);
+            const trimmed = this.trimTablePrefix(table, key);
+            const qualified = `${table}.${trimmed}`;
+            const placeholder = this.serializeUpdateValue(value, params, qualified);
             placeholders.push(placeholder);
         }
 


### PR DESCRIPTION
## Summary
- reuse update-style operand normalization in PostQueryBuilder so inserts validate operators and stringify JSON payloads
- add JSON column to test fixtures for insert serialization coverage
- extend SQL builder tests to verify JSON object inserts and operator-shaped payload rejection

## Testing
- npm test *(fails: Vitest RangeError `Invalid count value: Infinity` stemming from zero-size TTY columns during reporter output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6ef08e688325bc32c975b45e3124)